### PR TITLE
Stop install flow when dependency bootstrap fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Dependency bootstrap failures now stop the install flow instead of being logged and silently ignored, preventing confusing downstream tool-install failures when a required prerequisite is missing.
 - Install state (receipts and shell-hook decisions) is now persisted even when the skill-target picker is canceled or errors, preventing silent data loss after successful installs.
 - `update tools <name>` and `uninstall <name>` now return an error when the requested tool does not exist in the catalog, instead of silently succeeding with an empty plan.
 - Tool selectors now accept both the catalog tool ID and the binary name (e.g., `difft` resolves to `difftastic`).

--- a/cmd/atb/runtime.go
+++ b/cmd/atb/runtime.go
@@ -28,6 +28,7 @@ import (
 )
 
 var (
+	errDependencyBootstrapFailed  = errors.New("dependency bootstrap failed")
 	errNoSupportedPackageManagers = errors.New("no supported package managers detected")
 	errSelfUpdateDevBuild         = errors.New("self-update is unavailable in development builds; use a released atb binary instead")
 )
@@ -685,6 +686,8 @@ func renderDependencyPlanPreview(stdout io.Writer, dependencies []pkgmgr.Depende
 }
 
 func installDependencies(ctx context.Context, stdout io.Writer, dependencies []pkgmgr.DependencyPlanItem) error {
+	var failed []string
+
 	for index, dependency := range dependencies {
 		if err := ctx.Err(); err != nil {
 			return fmt.Errorf("dependency install canceled: %w", err)
@@ -706,6 +709,8 @@ func installDependencies(ctx context.Context, stdout io.Writer, dependencies []p
 				return wrapError("write dependency failure", writeErr)
 			}
 
+			failed = append(failed, dependency.Name)
+
 			continue
 		}
 
@@ -718,6 +723,10 @@ func installDependencies(ctx context.Context, stdout io.Writer, dependencies []p
 		if _, err := fmt.Fprintln(stdout); err != nil {
 			return wrapError("write dependency spacing", err)
 		}
+	}
+
+	if len(failed) > 0 {
+		return fmt.Errorf("%w: %s", errDependencyBootstrapFailed, strings.Join(failed, ", "))
 	}
 
 	return nil

--- a/cmd/atb/runtime_test.go
+++ b/cmd/atb/runtime_test.go
@@ -7,10 +7,12 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/ametel01/agents-toolbelt/internal/catalog"
+	"github.com/ametel01/agents-toolbelt/internal/pkgmgr"
 	"github.com/ametel01/agents-toolbelt/internal/skill"
 	"github.com/ametel01/agents-toolbelt/internal/state"
 	"github.com/ametel01/agents-toolbelt/internal/verify"
@@ -191,6 +193,68 @@ func TestRunSelfUpdateRejectsDevelopmentBuilds(t *testing.T) {
 		t.Fatalf("runSelfUpdate() error = %v, want %v", err, errSelfUpdateDevBuild)
 	}
 }
+
+func TestInstallDependenciesStopsOnFailure(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+
+	dependencies := []pkgmgr.DependencyPlanItem{
+		{
+			Name:    "cargo",
+			Manager: failingManager{name: "apt"},
+			Method:  catalog.InstallMethod{Manager: "apt", Command: []string{"echo", "install"}},
+		},
+	}
+
+	err := installDependencies(context.Background(), &stdout, dependencies)
+	if !errors.Is(err, errDependencyBootstrapFailed) {
+		t.Fatalf("installDependencies() error = %v, want %v", err, errDependencyBootstrapFailed)
+	}
+
+	if !strings.Contains(err.Error(), "cargo") {
+		t.Fatalf("error = %q, want mention of failed dependency name", err)
+	}
+}
+
+func TestInstallDependenciesSucceedsWhenAllPass(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+
+	dependencies := []pkgmgr.DependencyPlanItem{
+		{
+			Name:    "go",
+			Manager: passingManager{name: "apt"},
+			Method:  catalog.InstallMethod{Manager: "apt", Command: []string{"echo", "install"}},
+		},
+	}
+
+	err := installDependencies(context.Background(), &stdout, dependencies)
+	if err != nil {
+		t.Fatalf("installDependencies() unexpected error = %v", err)
+	}
+}
+
+var errFakeInstall = errors.New("install failed")
+
+type failingManager struct{ name string }
+
+func (m failingManager) Name() string    { return m.name }
+func (m failingManager) Available() bool { return true }
+func (m failingManager) Install(_ context.Context, _ catalog.InstallMethod) error {
+	return errFakeInstall
+}
+func (m failingManager) Update(_ context.Context, _ catalog.InstallMethod) error    { return nil }
+func (m failingManager) Uninstall(_ context.Context, _ catalog.InstallMethod) error { return nil }
+
+type passingManager struct{ name string }
+
+func (m passingManager) Name() string                                               { return m.name }
+func (m passingManager) Available() bool                                            { return true }
+func (m passingManager) Install(_ context.Context, _ catalog.InstallMethod) error   { return nil }
+func (m passingManager) Update(_ context.Context, _ catalog.InstallMethod) error    { return nil }
+func (m passingManager) Uninstall(_ context.Context, _ catalog.InstallMethod) error { return nil }
 
 func mustLoadRegistry(t *testing.T) catalog.Registry {
 	t.Helper()


### PR DESCRIPTION
## Summary
- `installDependencies` now collects failed dependency names and returns `errDependencyBootstrapFailed` after the loop, stopping the main install plan from running with missing prerequisites.
- Adds focused tests for both failure and success paths.
- Updates CHANGELOG with the fix.

## Test plan
- [x] `TestInstallDependenciesStopsOnFailure` — verifies error is returned when a dependency install fails
- [x] `TestInstallDependenciesSucceedsWhenAllPass` — verifies no error when all dependencies install successfully
- [x] `make verify` passes (fmt, vet, lint, test, build, vulncheck)

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)