### PR TITLE
Detect shell hooks using exact uncommented matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Shell-hook detection now matches exact uncommented lines instead of any substring, preventing commented-out hooks from blocking real hook installation.
 - Dependency bootstrap failures now stop the install flow instead of being logged and silently ignored, preventing confusing downstream tool-install failures when a required prerequisite is missing.
 - Install state (receipts and shell-hook decisions) is now persisted even when the skill-target picker is canceled or errors, preventing silent data loss after successful installs.
 - `update tools <name>` and `uninstall <name>` now return an error when the requested tool does not exist in the catalog, instead of silently succeeding with an empty plan.

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -76,11 +76,14 @@ func Suggestions(tools []catalog.Tool) []Suggestion {
 // ApplyConfirmedSuggestions appends missing init lines and records applied state.
 func ApplyConfirmedSuggestions(suggestions []Suggestion, st *state.State) error {
 	for _, suggestion := range suggestions {
-		if err := appendInitLine(suggestion.RCFile, suggestion.InitLine); err != nil {
+		written, err := appendInitLine(suggestion.RCFile, suggestion.InitLine)
+		if err != nil {
 			return err
 		}
 
-		recordHookStatus(st, suggestion.ToolID, shellHookApplied, time.Now().UTC())
+		if written {
+			recordHookStatus(st, suggestion.ToolID, shellHookApplied, time.Now().UTC())
+		}
 	}
 
 	return nil
@@ -100,7 +103,7 @@ func MarkSuggestedSuggestions(suggestions []Suggestion, st *state.State) {
 	}
 }
 
-func appendInitLine(path, initLine string) error {
+func appendInitLine(path, initLine string) (bool, error) {
 	//nolint:gosec // The rc file path is derived from the detected shell and user home directory.
 	content, err := os.ReadFile(path)
 	switch {
@@ -108,15 +111,15 @@ func appendInitLine(path, initLine string) error {
 	case os.IsNotExist(err):
 		content = nil
 	default:
-		return fmt.Errorf("read rc file %s: %w", path, err)
+		return false, fmt.Errorf("read rc file %s: %w", path, err)
 	}
 
-	if strings.Contains(string(content), initLine) {
-		return nil
+	if containsUncommentedLine(string(content), initLine) {
+		return false, nil
 	}
 
 	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
-		return fmt.Errorf("create rc file directory for %s: %w", path, err)
+		return false, fmt.Errorf("create rc file directory for %s: %w", path, err)
 	}
 
 	var builder strings.Builder
@@ -130,7 +133,7 @@ func appendInitLine(path, initLine string) error {
 
 	tempFile, err := os.CreateTemp(filepath.Dir(path), ".rc-*.tmp")
 	if err != nil {
-		return fmt.Errorf("create temp rc file for %s: %w", path, err)
+		return false, fmt.Errorf("create temp rc file for %s: %w", path, err)
 	}
 
 	tempPath := tempFile.Name()
@@ -138,22 +141,39 @@ func appendInitLine(path, initLine string) error {
 		_ = tempFile.Close()
 		_ = os.Remove(tempPath)
 
-		return fmt.Errorf("write temp rc file for %s: %w", path, err)
+		return false, fmt.Errorf("write temp rc file for %s: %w", path, err)
 	}
 
 	if err := tempFile.Close(); err != nil {
 		_ = os.Remove(tempPath)
 
-		return fmt.Errorf("close temp rc file for %s: %w", path, err)
+		return false, fmt.Errorf("close temp rc file for %s: %w", path, err)
 	}
 
 	if err := os.Rename(tempPath, path); err != nil {
 		_ = os.Remove(tempPath)
 
-		return fmt.Errorf("rename temp rc file to %s: %w", path, err)
+		return false, fmt.Errorf("rename temp rc file to %s: %w", path, err)
 	}
 
-	return nil
+	return true, nil
+}
+
+// containsUncommentedLine reports whether any uncommented line in content
+// matches initLine exactly after trimming whitespace.
+func containsUncommentedLine(content, initLine string) bool {
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+
+		if trimmed == initLine {
+			return true
+		}
+	}
+
+	return false
 }
 
 func initLineForTool(toolID, shellName string) (string, bool) {

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -88,6 +88,106 @@ func TestApplyConfirmedSuggestionsIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestApplySkipsCommentedOutHook(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("SHELL", "/bin/bash")
+
+	rcFile := filepath.Join(homeDir, ".bashrc")
+	initLine := `eval "$(direnv hook bash)"`
+
+	// Write a commented-out version of the init line.
+	//nolint:gosec // Test fixture written to a temp directory.
+	if err := os.WriteFile(rcFile, []byte("# "+initLine+"\n"), 0o644); err != nil {
+		t.Fatalf("os.WriteFile() error = %v", err)
+	}
+
+	suggestions := []Suggestion{{
+		ToolID:   "direnv",
+		ToolName: "direnv",
+		Shell:    "bash",
+		RCFile:   rcFile,
+		InitLine: initLine,
+		Required: true,
+	}}
+
+	var st state.State
+	if err := ApplyConfirmedSuggestions(suggestions, &st); err != nil {
+		t.Fatalf("ApplyConfirmedSuggestions() error = %v", err)
+	}
+
+	//nolint:gosec // The rc file path is derived from the test temp HOME.
+	data, err := os.ReadFile(rcFile)
+	if err != nil {
+		t.Fatalf("os.ReadFile(%q) error = %v", rcFile, err)
+	}
+
+	// The uncommented init line should have been appended.
+	if strings.Count(string(data), initLine) != 2 { // one commented, one real
+		t.Fatalf("rc file contents = %q, want both commented and uncommented init lines", string(data))
+	}
+
+	receipt, ok := st.Tool("direnv")
+	if !ok {
+		t.Fatal("state.Tool(\"direnv\") did not find a receipt")
+	}
+
+	if receipt.ShellHookStatus != shellHookApplied {
+		t.Fatalf("receipt.ShellHookStatus = %q, want %q", receipt.ShellHookStatus, shellHookApplied)
+	}
+}
+
+func TestContainsUncommentedLine(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		content  string
+		initLine string
+		want     bool
+	}{
+		{
+			name:     "exact match",
+			content:  "eval \"$(direnv hook bash)\"\n",
+			initLine: "eval \"$(direnv hook bash)\"",
+			want:     true,
+		},
+		{
+			name:     "commented out",
+			content:  "# eval \"$(direnv hook bash)\"\n",
+			initLine: "eval \"$(direnv hook bash)\"",
+			want:     false,
+		},
+		{
+			name:     "with leading spaces",
+			content:  "  eval \"$(direnv hook bash)\"\n",
+			initLine: "eval \"$(direnv hook bash)\"",
+			want:     true,
+		},
+		{
+			name:     "empty file",
+			content:  "",
+			initLine: "eval \"$(direnv hook bash)\"",
+			want:     false,
+		},
+		{
+			name:     "substring only",
+			content:  "something eval \"$(direnv hook bash)\" extra\n",
+			initLine: "eval \"$(direnv hook bash)\"",
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := containsUncommentedLine(tt.content, tt.initLine); got != tt.want {
+				t.Fatalf("containsUncommentedLine() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestMarkDeclinedSuggestions(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- `appendInitLine` now scans line-by-line and only considers uncommented, trimmed lines as matches, fixing the bug where `# eval "$(direnv hook bash)"` blocked the real hook from being written.
- `ApplyConfirmedSuggestions` now only records `shellHookApplied` when a write actually occurred.
- Adds `containsUncommentedLine` helper with comprehensive table-driven tests.

## Test plan
- [x] `TestApplySkipsCommentedOutHook` — verifies commented-out hooks don't block real hook installation
- [x] `TestContainsUncommentedLine` — table-driven tests for exact match, commented, leading spaces, empty, and substring cases
- [x] Existing `TestApplyConfirmedSuggestionsIsIdempotent` still passes
- [x] `make verify` passes

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed shell hook detection to only match active, uncommented configuration lines, preventing commented-out hooks from incorrectly blocking new hook installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->