### PR TITLE
Use receipt-stored lifecycle commands for managed update/uninstall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Managed update and uninstall now prefer lifecycle commands stored in install receipts instead of always re-selecting from the current catalog, preventing breakage when the catalog changes after install.
 - Shell-hook detection now matches exact uncommented lines instead of any substring, preventing commented-out hooks from blocking real hook installation.
 - Dependency bootstrap failures now stop the install flow instead of being logged and silently ignored, preventing confusing downstream tool-install failures when a required prerequisite is missing.
 - Install state (receipts and shell-hook decisions) is now persisted even when the skill-target picker is canceled or errors, preventing silent data loss after successful installs.

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -277,6 +277,114 @@ func TestBuildUninstallPlanUnknownToolReturnsError(t *testing.T) {
 	}
 }
 
+func TestBuildUpdatePlanPrefersReceiptCommands(t *testing.T) {
+	t.Parallel()
+
+	registry := mustLoadRegistry(t)
+	rg := mustTool(t, registry, "rg")
+
+	snapshot := discovery.Snapshot{
+		Tools: map[string]discovery.ToolPresence{
+			"rg": {
+				Tool:      rg,
+				Ownership: state.OwnershipManaged,
+				Receipt: &state.ToolState{
+					ToolID:         "rg",
+					Ownership:      state.OwnershipManaged,
+					InstallManager: "brew",
+					InstallCommand: []string{"brew", "install", "ripgrep-custom"},
+					UpdateCommand:  []string{"brew", "upgrade", "ripgrep-custom"},
+				},
+			},
+		},
+	}
+
+	plan, err := BuildUpdatePlan(snapshot, []pkgmgr.Manager{fakeManager{name: "brew"}}, "")
+	if err != nil {
+		t.Fatalf("BuildUpdatePlan() error = %v", err)
+	}
+
+	if len(plan.Actions) != 1 {
+		t.Fatalf("len(plan.Actions) = %d, want 1", len(plan.Actions))
+	}
+
+	if plan.Actions[0].Method.UpdateCommand[2] != "ripgrep-custom" {
+		t.Fatalf("plan.Actions[0].Method.UpdateCommand = %v, want receipt-stored command", plan.Actions[0].Method.UpdateCommand)
+	}
+}
+
+func TestBuildUninstallPlanPrefersReceiptCommands(t *testing.T) {
+	t.Parallel()
+
+	registry := mustLoadRegistry(t)
+	rg := mustTool(t, registry, "rg")
+
+	snapshot := discovery.Snapshot{
+		Tools: map[string]discovery.ToolPresence{
+			"rg": {
+				Tool:      rg,
+				Ownership: state.OwnershipManaged,
+				Receipt: &state.ToolState{
+					ToolID:           "rg",
+					Ownership:        state.OwnershipManaged,
+					InstallManager:   "brew",
+					InstallCommand:   []string{"brew", "install", "ripgrep-custom"},
+					UninstallCommand: []string{"brew", "uninstall", "ripgrep-custom"},
+				},
+			},
+		},
+	}
+
+	plan, err := BuildUninstallPlan(snapshot, []pkgmgr.Manager{fakeManager{name: "brew"}}, []string{"rg"}, false)
+	if err != nil {
+		t.Fatalf("BuildUninstallPlan() error = %v", err)
+	}
+
+	if len(plan.Actions) != 1 {
+		t.Fatalf("len(plan.Actions) = %d, want 1", len(plan.Actions))
+	}
+
+	if plan.Actions[0].Method.UninstallCommand[2] != "ripgrep-custom" {
+		t.Fatalf("plan.Actions[0].Method.UninstallCommand = %v, want receipt-stored command", plan.Actions[0].Method.UninstallCommand)
+	}
+}
+
+func TestBuildUpdatePlanFallsToCatalogWithoutReceiptCommands(t *testing.T) {
+	t.Parallel()
+
+	registry := mustLoadRegistry(t)
+	rg := mustTool(t, registry, "rg")
+
+	snapshot := discovery.Snapshot{
+		Tools: map[string]discovery.ToolPresence{
+			"rg": {
+				Tool:      rg,
+				Ownership: state.OwnershipManaged,
+				Receipt: &state.ToolState{
+					ToolID:         "rg",
+					Ownership:      state.OwnershipManaged,
+					InstallManager: "brew",
+					// No stored commands — should fall back to catalog.
+				},
+			},
+		},
+	}
+
+	plan, err := BuildUpdatePlan(snapshot, []pkgmgr.Manager{fakeManager{name: "brew"}}, "")
+	if err != nil {
+		t.Fatalf("BuildUpdatePlan() error = %v", err)
+	}
+
+	if len(plan.Actions) != 1 {
+		t.Fatalf("len(plan.Actions) = %d, want 1", len(plan.Actions))
+	}
+
+	// Should fall back to catalog method.
+	if plan.Actions[0].Method.Manager != "brew" {
+		t.Fatalf("plan.Actions[0].Method.Manager = %q, want %q", plan.Actions[0].Method.Manager, "brew")
+	}
+}
+
 func TestBuildUninstallPlanMatchesByBinaryName(t *testing.T) {
 	t.Parallel()
 

--- a/internal/plan/uninstall.go
+++ b/internal/plan/uninstall.go
@@ -51,7 +51,7 @@ func BuildUninstallPlan(
 			continue
 		}
 
-		method, manager, ok := methodForReceipt(presence.Tool, presence.Receipt.InstallManager, managers)
+		method, manager, ok := methodForReceipt(presence.Tool, presence.Receipt, managers)
 		if !ok {
 			actions = append(actions, Action{
 				Tool:   presence.Tool,
@@ -75,20 +75,49 @@ func BuildUninstallPlan(
 	return Plan{Actions: actions}, nil
 }
 
-func methodForReceipt(tool catalog.Tool, installManager string, managers []pkgmgr.Manager) (catalog.InstallMethod, pkgmgr.Manager, bool) {
-	for _, manager := range managers {
-		if manager.Name() != installManager {
-			continue
-		}
+func methodForReceipt(
+	tool catalog.Tool,
+	receipt *state.ToolState,
+	managers []pkgmgr.Manager,
+) (catalog.InstallMethod, pkgmgr.Manager, bool) {
+	manager := findManager(receipt.InstallManager, managers)
+	if manager == nil {
+		return catalog.InstallMethod{}, nil, false
+	}
 
-		for _, method := range tool.InstallMethods {
-			if method.Manager == installManager {
-				return method, manager, true
-			}
+	if hasStoredCommands(receipt) {
+		return catalog.InstallMethod{
+			Manager:          receipt.InstallManager,
+			Package:          receipt.InstallPackage,
+			Command:          receipt.InstallCommand,
+			UpdateCommand:    receipt.UpdateCommand,
+			UninstallCommand: receipt.UninstallCommand,
+		}, manager, true
+	}
+
+	for _, method := range tool.InstallMethods {
+		if method.Manager == receipt.InstallManager {
+			return method, manager, true
 		}
 	}
 
 	return catalog.InstallMethod{}, nil, false
+}
+
+func findManager(name string, managers []pkgmgr.Manager) pkgmgr.Manager {
+	for _, m := range managers {
+		if m.Name() == name {
+			return m
+		}
+	}
+
+	return nil
+}
+
+func hasStoredCommands(receipt *state.ToolState) bool {
+	return len(receipt.InstallCommand) > 0 ||
+		len(receipt.UpdateCommand) > 0 ||
+		len(receipt.UninstallCommand) > 0
 }
 
 // resolveSelector checks whether selector matches any tool in the snapshot by

--- a/internal/plan/update.go
+++ b/internal/plan/update.go
@@ -25,7 +25,7 @@ func BuildUpdatePlan(snapshot discovery.Snapshot, managers []pkgmgr.Manager, too
 			continue
 		}
 
-		method, manager, ok := methodForReceipt(presence.Tool, presence.Receipt.InstallManager, managers)
+		method, manager, ok := methodForReceipt(presence.Tool, presence.Receipt, managers)
 		if !ok {
 			actions = append(actions, Action{
 				Tool:   presence.Tool,


### PR DESCRIPTION
## Summary
- `methodForReceipt` now prefers lifecycle commands stored in install receipts when present, falling back to catalog methods only when receipts lack stored commands.
- Adds `findManager` and `hasStoredCommands` helpers to keep the logic clean.
- Adds focused tests for receipt-preference, fallback, and both update/uninstall paths.

## Test plan
- [x] `TestBuildUpdatePlanPrefersReceiptCommands` — verifies receipt commands are used over catalog
- [x] `TestBuildUninstallPlanPrefersReceiptCommands` — same for uninstall
- [x] `TestBuildUpdatePlanFallsToCatalogWithoutReceiptCommands` — verifies fallback when receipt has no stored commands
- [x] All existing plan tests pass
- [x] `make verify` passes

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)