### PR TITLE
Preserve selected skill targets during update/uninstall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Update and uninstall now reuse the skill targets selected during install instead of always regenerating for all targets, preventing skill files from appearing in agent directories the user never opted into.
 - Managed update and uninstall now prefer lifecycle commands stored in install receipts instead of always re-selecting from the current catalog, preventing breakage when the catalog changes after install.
 - Shell-hook detection now matches exact uncommented lines instead of any substring, preventing commented-out hooks from blocking real hook installation.
 - Dependency bootstrap failures now stop the install flow instead of being logged and silently ignored, preventing confusing downstream tool-install failures when a required prerequisite is missing.

--- a/cmd/atb/runtime.go
+++ b/cmd/atb/runtime.go
@@ -162,6 +162,8 @@ func finishInstall(ctx context.Context, stdout io.Writer, installCtx *installCon
 		return wrapError("write skip message", writeErr)
 	}
 
+	installCtx.stateData.SkillTargets = targetIDs(targets)
+
 	if err := persistVerifiedSkill(ctx, installCtx.registry, &installCtx.stateData, liveVerifier{}, stdout, targets); err != nil {
 		return wrapError("persist verified skill", err)
 	}
@@ -368,7 +370,7 @@ func runToolUpdate(ctx context.Context, stdout, stderr io.Writer, toolID string)
 		return wrapError("execute update plan", err)
 	}
 
-	if err := persistVerifiedSkill(ctx, registry, &stateData, liveVerifier{}, stdout, skill.AllTargets()); err != nil {
+	if err := persistVerifiedSkill(ctx, registry, &stateData, liveVerifier{}, stdout, resolveStoredTargets(stateData)); err != nil {
 		return wrapError("persist verified skill", err)
 	}
 
@@ -416,7 +418,7 @@ func runUninstall(ctx context.Context, stdout, stderr io.Writer, toolIDs []strin
 		return wrapError("execute uninstall plan", err)
 	}
 
-	if err := persistVerifiedSkill(ctx, registry, &stateData, liveVerifier{}, stdout, skill.AllTargets()); err != nil {
+	if err := persistVerifiedSkill(ctx, registry, &stateData, liveVerifier{}, stdout, resolveStoredTargets(stateData)); err != nil {
 		return wrapError("persist verified skill", err)
 	}
 
@@ -536,6 +538,40 @@ func selectDependencies(selected []catalog.Tool, managers []pkgmgr.Manager, yes 
 	}
 
 	return selectedDependencies, nil
+}
+
+func resolveStoredTargets(st state.State) []skill.Target {
+	if len(st.SkillTargets) == 0 {
+		return skill.AllTargets()
+	}
+
+	all := skill.AllTargets()
+	targets := make([]skill.Target, 0, len(st.SkillTargets))
+
+	for _, id := range st.SkillTargets {
+		for _, target := range all {
+			if target.ID == id {
+				targets = append(targets, target)
+
+				break
+			}
+		}
+	}
+
+	if len(targets) == 0 {
+		return skill.AllTargets()
+	}
+
+	return targets
+}
+
+func targetIDs(targets []skill.Target) []string {
+	ids := make([]string, 0, len(targets))
+	for _, target := range targets {
+		ids = append(ids, target.ID)
+	}
+
+	return ids
 }
 
 func selectTargets(yes bool) ([]skill.Target, error) {

--- a/cmd/atb/runtime_test.go
+++ b/cmd/atb/runtime_test.go
@@ -178,6 +178,64 @@ func TestFinishInstallPersistsStateWithNormalTargets(t *testing.T) {
 	}
 }
 
+func TestResolveStoredTargets(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns all targets when state has no stored targets", func(t *testing.T) {
+		t.Parallel()
+
+		st := state.State{Version: 1}
+		targets := resolveStoredTargets(st)
+
+		if len(targets) != len(skill.AllTargets()) {
+			t.Fatalf("len(targets) = %d, want %d", len(targets), len(skill.AllTargets()))
+		}
+	})
+
+	t.Run("returns only stored targets", func(t *testing.T) {
+		t.Parallel()
+
+		st := state.State{Version: 1, SkillTargets: []string{"claude"}}
+		targets := resolveStoredTargets(st)
+
+		if len(targets) != 1 {
+			t.Fatalf("len(targets) = %d, want 1", len(targets))
+		}
+
+		if targets[0].ID != "claude" {
+			t.Fatalf("targets[0].ID = %q, want %q", targets[0].ID, "claude")
+		}
+	})
+
+	t.Run("falls back to all when stored IDs are invalid", func(t *testing.T) {
+		t.Parallel()
+
+		st := state.State{Version: 1, SkillTargets: []string{"nonexistent"}}
+		targets := resolveStoredTargets(st)
+
+		if len(targets) != len(skill.AllTargets()) {
+			t.Fatalf("len(targets) = %d, want %d (fallback to all)", len(targets), len(skill.AllTargets()))
+		}
+	})
+}
+
+func TestTargetIDs(t *testing.T) {
+	t.Parallel()
+
+	targets := skill.AllTargets()
+	ids := targetIDs(targets)
+
+	if len(ids) != len(targets) {
+		t.Fatalf("len(ids) = %d, want %d", len(ids), len(targets))
+	}
+
+	for i, target := range targets {
+		if ids[i] != target.ID {
+			t.Fatalf("ids[%d] = %q, want %q", i, ids[i], target.ID)
+		}
+	}
+}
+
 func TestRunSelfUpdateRejectsDevelopmentBuilds(t *testing.T) {
 	t.Parallel()
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -25,9 +25,10 @@ var (
 
 // State represents the persisted atb state file contents.
 type State struct {
-	Version   int                  `json:"version"`
-	Tools     map[string]ToolState `json:"tools"`
-	LastRunAt time.Time            `json:"last_run_at"`
+	Version      int                  `json:"version"`
+	Tools        map[string]ToolState `json:"tools"`
+	SkillTargets []string             `json:"skill_targets,omitempty"`
+	LastRunAt    time.Time            `json:"last_run_at"`
 }
 
 // ToolState records ownership and verification data for one tool.


### PR DESCRIPTION
## Summary
- Install now persists the user's selected skill target IDs in `state.SkillTargets`.
- `runToolUpdate` and `runUninstall` now call `resolveStoredTargets()` which reads from state, falling back to `AllTargets()` for legacy state without stored targets.
- Adds `resolveStoredTargets` and `targetIDs` helpers with focused tests.

## Test plan
- [x] `TestResolveStoredTargets` — covers empty state (fallback), single stored target, and invalid stored IDs (fallback)
- [x] `TestTargetIDs` — verifies ID extraction from targets
- [x] All existing tests pass
- [x] `make verify` passes

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)