### PR TITLE
Clear stale version metadata when binary verification fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Stale version metadata is now cleared when binary verification detects a missing tool, preventing misleading version output for tools that are no longer installed.
 - `.golangci.yml` is now directly runnable with `golangci-lint run` by removing the obsolete `gosimple` linter entry (merged into `staticcheck` in v2) and the wrapper script workaround.
 - Update and uninstall now reuse the skill targets selected during install instead of always regenerating for all targets, preventing skill files from appearing in agent directories the user never opted into.
 - Managed update and uninstall now prefer lifecycle commands stored in install receipts instead of always re-selecting from the current catalog, preventing breakage when the catalog changes after install.

--- a/cmd/atb/runtime.go
+++ b/cmd/atb/runtime.go
@@ -651,6 +651,7 @@ func refreshVerifiedTools(
 			if presence.Receipt != nil {
 				receipt := *presence.Receipt
 				receipt.BinaryPath = ""
+				receipt.Version = ""
 				receipt.LastVerifyAt = time.Now().UTC()
 				receipt.LastVerifyOK = false
 				receipt.LastVerifyError = "binary not found"

--- a/cmd/atb/runtime_test.go
+++ b/cmd/atb/runtime_test.go
@@ -78,6 +78,48 @@ func TestRefreshVerifiedToolsIncludesExternalTools(t *testing.T) {
 	}
 }
 
+func TestRefreshVerifiedToolsClearsVersionForMissingBinary(t *testing.T) {
+	registry := mustLoadRegistry(t)
+	// Empty PATH so jq won't be found.
+	t.Setenv("PATH", t.TempDir())
+
+	st := state.State{
+		Version: 1,
+		Tools: map[string]state.ToolState{
+			"jq": {
+				ToolID:         "jq",
+				Bin:            "jq",
+				Ownership:      state.OwnershipManaged,
+				InstallManager: "brew",
+				BinaryPath:     "/usr/local/bin/jq",
+				Version:        "1.7.1",
+			},
+		},
+	}
+
+	_, err := refreshVerifiedTools(context.Background(), registry, &st, fakeRuntimeVerifier{})
+	if err != nil {
+		t.Fatalf("refreshVerifiedTools() error = %v", err)
+	}
+
+	receipt, ok := st.Tool("jq")
+	if !ok {
+		t.Fatal("state.Tool(\"jq\") not found")
+	}
+
+	if receipt.BinaryPath != "" {
+		t.Fatalf("receipt.BinaryPath = %q, want empty", receipt.BinaryPath)
+	}
+
+	if receipt.Version != "" {
+		t.Fatalf("receipt.Version = %q, want empty", receipt.Version)
+	}
+
+	if receipt.LastVerifyOK {
+		t.Fatal("receipt.LastVerifyOK = true, want false")
+	}
+}
+
 func TestFinishInstallPersistsStateWhenTargetsCanceled(t *testing.T) {
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)


### PR DESCRIPTION
## Summary
- `refreshVerifiedTools` now clears `Version` alongside `BinaryPath` when a previously known binary is no longer found on PATH.

## Test plan
- [x] `TestRefreshVerifiedToolsClearsVersionForMissingBinary` — verifies both BinaryPath and Version are cleared
- [x] `make verify` passes

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)