### PR TITLE
Surface mkdir failures in scripts/install.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- The standalone installer now surfaces `mkdir -p` failures directly instead of suppressing the error and failing later with weaker diagnostics.
 - Stale version metadata is now cleared when binary verification detects a missing tool, preventing misleading version output for tools that are no longer installed.
 - `.golangci.yml` is now directly runnable with `golangci-lint run` by removing the obsolete `gosimple` linter entry (merged into `staticcheck` in v2) and the wrapper script workaround.
 - Update and uninstall now reuse the skill targets selected during install instead of always regenerating for all targets, preventing skill files from appearing in agent directories the user never opted into.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -101,7 +101,12 @@ install_binary() {
   local source_path="$1"
   local target_path="${install_dir}/${binary_name}"
 
-  mkdir -p "$install_dir" 2>/dev/null || true
+  if ! mkdir -p "$install_dir" 2>&1; then
+    fail \
+      "failed to create install directory: $install_dir" \
+      "check that the parent directory exists and you have write permission" \
+      "set ATB_INSTALL_DIR to a writable directory on your PATH"
+  fi
 
   if [[ -w "$install_dir" ]]; then
     install -m 0755 "$source_path" "$target_path"


### PR DESCRIPTION
## Summary
- `install_binary` now fails immediately with a clear error when `mkdir -p` cannot create the install directory, instead of suppressing the error with `2>/dev/null || true`.

## Test plan
- [x] Verified manually: running with `ATB_INSTALL_DIR=/nonexistent/deep/path` now shows the `mkdir` failure directly
- [x] Normal install path continues to work as before

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)