### PR TITLE
Inject input into confirmApply instead of hardcoding os.Stdin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - `State.Tool()` now returns `(ToolState, bool)` by value instead of a pointer to a copy, making copy semantics explicit and eliminating a potential mutation footgun.
+- `confirmApply` now reads from an injected `io.Reader` instead of hardcoding `os.Stdin`, improving testability and enabling non-interactive integrations.
 
 ### Fixed
 - The standalone installer now surfaces `mkdir -p` failures directly instead of suppressing the error and failing later with weaker diagnostics.

--- a/cmd/atb/install.go
+++ b/cmd/atb/install.go
@@ -9,7 +9,7 @@ func newInstallCmd() *cobra.Command {
 		Use:   "install",
 		Short: "Install selected tools",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runInstall(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), yes)
+			return runInstall(cmd.Context(), cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr(), yes)
 		},
 	}
 

--- a/cmd/atb/runtime.go
+++ b/cmd/atb/runtime.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"os/exec"
 	"runtime"
 	"slices"
@@ -71,7 +70,7 @@ func (liveVerifier) Check(ctx context.Context, tool catalog.Tool) (verify.Verify
 	return result, nil
 }
 
-func runInstall(ctx context.Context, stdout, stderr io.Writer, yes bool) error {
+func runInstall(ctx context.Context, stdin io.Reader, stdout, stderr io.Writer, yes bool) error {
 	installCtx, err := prepareInstall(stderr, yes)
 	if err != nil {
 		return err
@@ -110,7 +109,7 @@ func runInstall(ctx context.Context, stdout, stderr io.Writer, yes bool) error {
 		return wrapError("execute install plan", err)
 	}
 
-	if err := applyShellWorkflow(stdout, yes, &installCtx.stateData, installCtx.selected); err != nil {
+	if err := applyShellWorkflow(stdin, stdout, yes, &installCtx.stateData, installCtx.selected); err != nil {
 		return wrapError("apply shell workflow", err)
 	}
 
@@ -427,7 +426,7 @@ func runUninstall(ctx context.Context, stdout, stderr io.Writer, toolIDs []strin
 	return nil
 }
 
-func applyShellWorkflow(stdout io.Writer, yes bool, st *state.State, tools []catalog.Tool) error {
+func applyShellWorkflow(stdin io.Reader, stdout io.Writer, yes bool, st *state.State, tools []catalog.Tool) error {
 	suggestions := shell.Suggestions(tools)
 	if len(suggestions) == 0 {
 		return nil
@@ -440,7 +439,7 @@ func applyShellWorkflow(stdout io.Writer, yes bool, st *state.State, tools []cat
 		return nil
 	}
 
-	apply, err := confirmApply(stdout)
+	apply, err := confirmApply(stdin, stdout)
 	if err != nil {
 		return wrapError("confirm shell hook application", err)
 	}
@@ -454,12 +453,12 @@ func applyShellWorkflow(stdout io.Writer, yes bool, st *state.State, tools []cat
 	return wrapError("apply shell hook suggestions", shell.ApplyConfirmedSuggestions(suggestions, st))
 }
 
-func confirmApply(stdout io.Writer) (bool, error) {
+func confirmApply(stdin io.Reader, stdout io.Writer) (bool, error) {
 	if _, err := fmt.Fprint(stdout, "Apply shell hook suggestions now? [y/N]: "); err != nil {
 		return false, wrapError("write shell hook prompt", err)
 	}
 
-	reader := bufio.NewReader(os.Stdin)
+	reader := bufio.NewReader(stdin)
 	answer, err := reader.ReadString('\n')
 	if err != nil {
 		return false, fmt.Errorf("read shell hook confirmation: %w", err)

--- a/cmd/atb/runtime_test.go
+++ b/cmd/atb/runtime_test.go
@@ -220,6 +220,37 @@ func TestFinishInstallPersistsStateWithNormalTargets(t *testing.T) {
 	}
 }
 
+func TestConfirmApplyFromInjectedInput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"yes", "y\n", true},
+		{"YES", "YES\n", true},
+		{"no", "n\n", false},
+		{"empty", "\n", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var stdout bytes.Buffer
+			got, err := confirmApply(strings.NewReader(tt.input), &stdout)
+			if err != nil {
+				t.Fatalf("confirmApply() error = %v", err)
+			}
+
+			if got != tt.want {
+				t.Fatalf("confirmApply() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestResolveStoredTargets(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- `confirmApply` now accepts an `io.Reader` parameter instead of hardcoding `os.Stdin`.
- Input is threaded from the command boundary via `cmd.InOrStdin()`.
- Adds table-driven test for confirmation flow with injected input.

## Test plan
- [x] `TestConfirmApplyFromInjectedInput` — table-driven tests for "y", "YES", "n", and empty input
- [x] Default CLI behavior still reads from stdin via `cmd.InOrStdin()`
- [x] `make verify` passes

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)