### PR TITLE
Return explicit result when updating an unmanaged tool by selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `confirmApply` now reads from an injected `io.Reader` instead of hardcoding `os.Stdin`, improving testability and enabling non-interactive integrations.
 
 ### Fixed
+- Targeted updates of externally managed tools now return an explicit skip reason instead of a silent empty plan.
 - Shell-hook prompting now skips tools whose hooks have already been applied or declined, and reconciles state to `applied` when the init line is already present in the rc file.
 - Canceling the skill-target picker during install now persists an explicit opt-out, preventing `update tools` and `uninstall` from writing skill files into default agent directories.
 - Lifecycle state is now saved immediately after install, update, and uninstall plan execution, before shell-hook prompting and skill generation, preventing receipt loss when post-processing steps fail.

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -234,6 +234,40 @@ func TestBuildUpdatePlanUnknownToolReturnsError(t *testing.T) {
 	}
 }
 
+func TestBuildUpdatePlanExternalToolReturnsSkip(t *testing.T) {
+	t.Parallel()
+
+	registry := mustLoadRegistry(t)
+	tool := mustTool(t, registry, "jq")
+
+	snapshot := discovery.Snapshot{
+		Tools: map[string]discovery.ToolPresence{
+			"jq": {
+				Tool:      tool,
+				Installed: true,
+				Ownership: state.OwnershipExternal,
+			},
+		},
+	}
+
+	plan, err := BuildUpdatePlan(snapshot, []pkgmgr.Manager{fakeManager{name: "brew"}}, "jq")
+	if err != nil {
+		t.Fatalf("BuildUpdatePlan() error = %v", err)
+	}
+
+	if len(plan.Actions) != 1 {
+		t.Fatalf("len(actions) = %d, want 1", len(plan.Actions))
+	}
+
+	if plan.Actions[0].Type != ActionSkip {
+		t.Fatalf("action type = %q, want %q", plan.Actions[0].Type, ActionSkip)
+	}
+
+	if plan.Actions[0].Reason != "tool is not managed by atb" {
+		t.Fatalf("action reason = %q, want %q", plan.Actions[0].Reason, "tool is not managed by atb")
+	}
+}
+
 func TestBuildUpdatePlanMatchesByBinaryName(t *testing.T) {
 	t.Parallel()
 

--- a/internal/plan/update.go
+++ b/internal/plan/update.go
@@ -22,6 +22,14 @@ func BuildUpdatePlan(snapshot discovery.Snapshot, managers []pkgmgr.Manager, too
 		}
 
 		if presence.Ownership != state.OwnershipManaged || presence.Receipt == nil {
+			if toolID != "" {
+				actions = append(actions, Action{
+					Tool:   presence.Tool,
+					Type:   ActionSkip,
+					Reason: "tool is not managed by atb",
+				})
+			}
+
 			continue
 		}
 


### PR DESCRIPTION
## Summary
- Targeted updates of externally managed tools now produce an explicit skip action with reason `"tool is not managed by atb"` instead of a silent empty plan
- Bulk updates (no selector) continue to silently skip external tools as before

Closes #28

## Test plan
- [x] `TestBuildUpdatePlanExternalToolReturnsSkip` — external tool produces skip action with reason
- [x] `TestBuildUpdatePlanUnknownToolReturnsError` — unknown selector still returns error (unchanged)
- [x] `TestBuildUpdatePlanManagedOnly` — bulk update behavior unchanged
- [x] All tests pass, `golangci-lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Targeted updates of externally managed tools now return an explicit skip reason instead of silently producing no result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->